### PR TITLE
Change default constraint naming

### DIFF
--- a/Global.props
+++ b/Global.props
@@ -3,14 +3,16 @@
   <Import Project="DotNetSdkMono.props" />
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.2.10</VersionPrefix>
+    <VersionPrefix>3.2.10.1</VersionPrefix>
     <Product>FluentMigrator</Product>
     <Copyright>Rev.com</Copyright>
     <Company>Rev.com</Company>
     <Authors>Rev.com</Authors>
+    <Description>Rev's fork for the FluentMigrator.Console found at https://github.com/revdotcom/fluentmigrator to handle our own flavor of default constraint naming.</Description>
     <PackageProjectUrl>https://github.com/revdotcom/fluentmigrator</PackageProjectUrl>
     <PackageIconUrl>https://github.com/revdotcom/fluentmigrator/raw/develop/docs/logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/revdotcom/fluentmigrator.git</RepositoryUrl>
+    <PackageReleaseNotes>Overide default constraint naming</PackageReleaseNotes>
     <RepositoryType>git</RepositoryType>
     <MinClientVersion>3.5</MinClientVersion>
     <IsPackable>false</IsPackable>

--- a/Global.props
+++ b/Global.props
@@ -3,7 +3,7 @@
   <Import Project="DotNetSdkMono.props" />
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.2.10.1</VersionPrefix>
+    <VersionPrefix>3.2.10</VersionPrefix>
     <Product>FluentMigrator</Product>
     <Copyright>Rev.com</Copyright>
     <Company>Rev.com</Company>

--- a/Global.props
+++ b/Global.props
@@ -3,22 +3,14 @@
   <Import Project="DotNetSdkMono.props" />
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.2.10</VersionPrefix>
     <Product>FluentMigrator</Product>
-    <Copyright>Sean Chambers and the FluentMigrator project 2008-2018</Copyright>
-    <Company>FluentMigrator Project</Company>
-    <Authors>Sean Chambers;Josh Coffman;Tom Marien;Mark Junker</Authors>
-    <PackageProjectUrl>https://github.com/fluentmigrator/fluentmigrator/wiki</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/fluentmigrator/fluentmigrator/blob/master/LICENSE.txt</PackageLicenseUrl>
-    <PackageReleaseNotes>Use of standard dependency injection, configuration and logging libraries.
-Simplification of in-process runner configuration and instantiation.
-dotnet-fm is now a global .NET Core 2.1 tool.
-Minimum .NET Framework version is 4.6.1.
-
-Details: https://github.com/fluentmigrator/fluentmigrator/releases
-    </PackageReleaseNotes>
-    <PackageIconUrl>https://github.com/fluentmigrator/fluentmigrator/raw/develop/docs/logo.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/fluentmigrator/fluentmigrator.git</RepositoryUrl>
+    <Copyright>Rev.com</Copyright>
+    <Company>Rev.com</Company>
+    <Authors>Rev.com</Authors>
+    <PackageProjectUrl>https://github.com/revdotcom/fluentmigrator</PackageProjectUrl>
+    <PackageIconUrl>https://github.com/revdotcom/fluentmigrator/raw/develop/docs/logo.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/revdotcom/fluentmigrator.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <MinClientVersion>3.5</MinClientVersion>
     <IsPackable>false</IsPackable>

--- a/README.md
+++ b/README.md
@@ -1,68 +1,13 @@
-# FluentMigrator [![(License)](https://img.shields.io/github/license/fluentmigrator/fluentmigrator.svg)](https://github.com/fluentmigrator/fluentmigrator/blob/master/LICENSE.txt) [![FluentMigrator.GitHub.Io Docs](https://img.shields.io/badge/docs-fluentmigrator-blue.svg)](https://fluentmigrator.github.io) [![Fluent-Migrator tag on Stack Overflow](https://img.shields.io/badge/stackoverflow-fluentmigrator-orange.svg)](https://stackoverflow.com/questions/tagged/fluent-migrator) [![NuGet downloads](https://img.shields.io/nuget/dt/FluentMigrator.svg)](https://www.nuget.org/packages/FluentMigrator/) 
+# Migrate.exe v3.2.10.1 (fork of v3.2.10)
 
-[Fluent Migrator](https://github.com/fluentmigrator/fluentmigrator) is a migration framework for .NET much like Ruby on Rails Migrations. Migrations are a structured way to alter your database schema and are an alternative to creating lots of sql scripts that have to be run manually by every developer involved. Migrations solve the problem of evolving a database schema for multiple databases (for example, the developer's local database, the test database and the production database). Database schema changes are described in classes written in C# that can be checked into a version control system.
+This is a build of a fork of https://github.com/fluentmigrator/fluentmigrator that is hosted here https://github.com/revdotcom/fluentmigrator
 
-# News
+It makes a very simple change of changing how we name the default constraints. It also changes the project to use the signed packages for the parts that the revdotcom code base also uses (FluentMigrator package). It also changes the global.props to point the user back to here for future discovery.
 
-3.0.0 is released and goes full "dependency injection".
-We also have a new [documentation website](https://fluentmigrator.github.io)!
+You should upload new versions to myget with the following commands. Replaces the version with the version you are basing the package on.
 
-Please read the [changelog](https://github.com/fluentmigrator/fluentmigrator/blob/master/CHANGELOG.md)
-or the upgrade guide for further information: [2.x to 3.0](https://fluentmigrator.github.io/articles/guides/upgrades/guide-2.0-to-3.0.html?tabs=di).
+From the FluentMigrator.Console folder run the following:
 
-# Packages
+`dotnet pack -c Release --include-symbols /p:SymbolPackageFormat=snupkg`
 
-Package Source      | Status   | Source Code Tree
---------------------|----------|-----------------
-NuGet (Releases)    | [![NuGet](https://img.shields.io/nuget/v/FluentMigrator.svg)](https://www.nuget.org/packages/FluentMigrator/) | [master](https://github.com/fluentmigrator/fluentmigrator/tree/master)
-Azure Artifacts (Prerelease)  | [![Azure Artifacts](https://feeds.dev.azure.com/fluentmigrator/22b31067-b424-416b-b89f-682210a37a55/_apis/public/Packaging/Feeds/55481ff8-c55e-44b4-ad6e-b6638cc22c2b/Packages/d298bf9a-9246-4834-a1ad-a056e046513a/Badge)](https://dev.azure.com/fluentmigrator/fluentmigrator/_packaging?_a=feed&feed=fluentmigrator) | [develop](https://github.com/fluentmigrator/fluentmigrator/tree/develop)
-
-The releases are stored on [nuget.org](https://nuget.org)
-while the CI builds are stored on [Azure Artifacts](https://dev.azure.com/fluentmigrator/fluentmigrator/_packaging?_a=feed&feed=fluentmigrator).
-
-:warning: The badge for the Azure Artifacts feed won't display prereleases.  [We're looking into this](https://github.com/fluentmigrator/fluentmigrator/issues/1180#issuecomment-662884030). We've recently migrated from MyGet to Azure Artifacts, ref [this notice](https://github.com/fluentmigrator/fluentmigrator/issues/1183).
-
-# Project Info
-
-|                           |         |
-|---------------------------|---------|
-| **Documentation**         | [On our GitHub pages](https://fluentmigrator.github.io) |
-| **Discussions**           | [![Gitter](https://img.shields.io/gitter/room/FluentMigrator/fluentmigrator.svg)](https://gitter.im/FluentMigrator/fluentmigrator) |
-| **Bug/Feature Tracking**  | [![GitHub issues](https://img.shields.io/github/issues/fluentmigrator/fluentmigrator.svg)](https://github.com/fluentmigrator/fluentmigrator/issues) |
-| **Build server (new)**    | [![AzureDevOps](https://img.shields.io/azure-devops/build/fluentmigrator/22b31067-b424-416b-b89f-682210a37a55/1)](https://dev.azure.com/fluentmigrator/fluentmigrator/_build?definitionId=1) |
-
-# Prerequisites
-
-| Tool                              | Consequences when not installed |
-|-----------------------------------|---------------------------------|
-| [Multilingual App Toolkit Editor](https://developer.microsoft.com/en-us/windows/develop/multilingual-app-toolkit) | You're unable to create translations. |
-| [Multilingual App Toolkit Extension (VS2017+)](https://marketplace.visualstudio.com/items?itemName=MultilingualAppToolkit.MultilingualAppToolkit-18308) | You get a compilation warning and the changed translation doesn't get compiled. |
-
-# Powered by
-
-<span>
-<a href="https://www.jetbrains.com"><img src="https://raw.githubusercontent.com/fluentmigrator/fluentmigrator/master/docs/jetbrains/jetbrains.png" alt="JetBrains"  width="15%" /></a>
-<a href="https://www.jetbrains.com/resharper"><img src="https://raw.githubusercontent.com/fluentmigrator/fluentmigrator/master/docs/jetbrains/logo.png" alt="ReSharper"  width="15%" /></a>
-</span>
-
-<a href="https://azure.microsoft.com/en-us/services/devops/"><img src="https://azurecomcdn.azureedge.net/cvt-2b18021399b1b3aa2c405a40ce4e9b89f162d9e5b3d6df838d13aae49f3608ea/images/shared/services/devops/pipelines-icon-80.png" alt="Azure DevOps"  width="20%" /></a>
-
-# Contributors
-
-A [long list](https://github.com/fluentmigrator/fluentmigrator/blob/master/CONTRIBUTORS.md) of everyone that has contributed to FluentMigrator. Thanks for all the Pull Requests!
-
-# Contributing
-
-Please see our guide on [how to contribute](https://fluentmigrator.github.io/articles/guides/contribution.html)
-
-# Third Party Contributions / FluentMigrator Ecosystem
-
-FluentMigrator has an actively developed and maintained ecosystem thanks to third party contributions. The following table summarizes some contributions (but are not endorsed):
-
-| GitHub/BitBucket | NuGet Package | Description |
-| ---------------- | ------------- | ----------- |
-| [EasyMigrator](https://bitbucket.org/quentin-starin/easymigrator/wiki/Home) | [EasyMigrator.FluentMigrator](https://www.nuget.org/packages/EasyMigrator.FluentMigrator) | EasyMigrator allows you to specify database schema using simple POCOs with minimally attributed fields to represent columns. EasyMigrator's core can be adapted to sit on top of various migration libraries. |
-| [FluentMigrator-Generator](https://github.com/ritterim/fluentmigrator-generator) | [FluentMigrator.Generator](https://www.nuget.org/packages/FluentMigrator.Generator/) | Adds a command to the package manager console to generate migrations for FluentMigrator. |
-| [AspNetBoilerplate](https://github.com/aspnetboilerplate/aspnetboilerplate) | [Abp.FluentMigrator](https://www.nuget.org/packages/Abp.FluentMigrator) | Adds fluent extensions specific to the entity model used by the ASP.NET Boilerplate architecture |
-| [Alt.FluentMigrator.VStudio](https://github.com/crimcol/Alt.FluentMigrator.VStudio) | [Alt.FluentMigrator.VStudio](https://www.nuget.org/packages/Alt.FluentMigrator.VStudio/) | Adds set of commands for Package Manager console:<br> - Add-FluentMigration<br> - Update-FluentDatabase<br> - Rollback-FluentDatabase |
-| [FAKE.FluentMigrator](https://github.com/fsharp/FAKE/blob/694f616c97fa242162cfd36db905d7df3156018f/help/markdown/todo-fluentmigrator.md) | [FAKE.FluentMigrator](https://www.nuget.org/packages/FAKE.FluentMigrator/) | FluentMigrator is a .NET library which helps to version database schema using incremental migrations which are described in C#. The basic idea of the FAKE helper is to run FluentMigrator over the existing database using compiled assembly with migrations. |
+` dotnet nuget push bin/Release/FluentMigrator.Console.3.2.10.1.nupkg -s https://www.myget.org/F/revdotcom/auth/YOURAPIKEYHERE/api/v3/index.json`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It makes a very simple change of changing how we name the default constraints. I
 
 You should upload new versions to myget with the following commands. Replaces the version with the version you are basing the package on.
 
-From the FluentMigrator.Console folder run the following:
+From the each folder, in order, run the following. FluentMigrator.SqlServer => FluentMigrator.Runner => FluentMigrator.Console
 
 `dotnet pack -c Release --include-symbols /p:SymbolPackageFormat=snupkg`
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-# Migrate.exe v3.2.10.1 (fork of v3.2.10)
+# Migrate.exe v3.2.10
 
 This is a build of a fork of https://github.com/fluentmigrator/fluentmigrator that is hosted here https://github.com/revdotcom/fluentmigrator
 
-It makes a very simple change of changing how we name the default constraints. It also changes the project to use the signed packages for the parts that the revdotcom code base also uses (FluentMigrator package). It also changes the global.props to point the user back to here for future discovery.
+It makes a very simple change of changing how we name the default constraints. It also changes the project to use the signed packages for the parts that the revdotcom code base also uses (FluentMigrator package). It also makes some minor changes the golbal.props file as well as adding a nuspec file to package up the FluentMigrator.Console for uploading to Rev's myget.
 
-You should upload new versions to myget with the following commands. Replaces the version with the version you are basing the package on.
+In order to upload the FluentMigrator.Console.
+1. Build the project from Visual Studio
+2. Make sure the nuspec version matches the version of FluentMigrator you are packing up
+3. Pack the output using the following command
+`dotnet pack -p:NuspecFile=.\Rev.FluentMigrator.Console.nuspec --output Rev.FluentMigrator.Console --no-build`
+4. Upload the package to myget using the following command (note you need to add the API key)
+`dotnet nuget push bin/Release/FluentMigrator.Console.3.2.10.nupkg -s https://www.myget.org/F/revdotcom/auth/YOURAPIKEYHERE/api/v3/index.json`
 
-From the each folder, in order, run the following. FluentMigrator.SqlServer => FluentMigrator.Runner => FluentMigrator.Console
 
-`dotnet pack -c Release --include-symbols /p:SymbolPackageFormat=snupkg`
-
-` dotnet nuget push bin/Release/FluentMigrator.Console.3.2.10.1.nupkg -s https://www.myget.org/F/revdotcom/auth/YOURAPIKEYHERE/api/v3/index.json`
+Note:
+When developing a new version make sure to add an extra dot version and add a dev post tag e.g. when working on 3.2.10 create new versions for every test like 3.2.10.1-dev. You want to create a unique version for every test to avoid issues with myget and local nuget package caching.

--- a/samples/FluentMigrator.Example.Migrations/FluentMigrator.Example.Migrations.csproj
+++ b/samples/FluentMigrator.Example.Migrations/FluentMigrator.Example.Migrations.csproj
@@ -10,12 +10,14 @@
   <Import Project="$(MSBuildThisFileDirectory)../../Global.props" />
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\FluentMigrator\FluentMigrator.csproj" />
     <ProjectReference Include="..\..\src\FluentMigrator.Runner\FluentMigrator.Runner.csproj" />
   </ItemGroup>
   <!-- Automatically include all *.sql files as embedded resources
   for use with Migration.Execute.EmbeddedScript(string EmbeddedSqlScriptName) -->
   <ItemGroup>
     <EmbeddedResource Include="**/*.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentMigrator" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/samples/FluentMigrator.Example.Migrator/FluentMigrator.Example.Migrator.csproj
+++ b/samples/FluentMigrator.Example.Migrator/FluentMigrator.Example.Migrator.csproj
@@ -17,6 +17,7 @@
     </COMReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FluentMigrator" Version="3.2.10" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />

--- a/src/FluentMigrator.Console/FluentMigrator.Console.csproj
+++ b/src/FluentMigrator.Console/FluentMigrator.Console.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\FluentMigrator.Runner\FluentMigrator.Runner.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FluentMigrator" Version="3.2.10" />
     <PackageReference Include="Npgsql" Version="3.2.7" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />

--- a/src/FluentMigrator.Console/FluentMigrator.Console.csproj
+++ b/src/FluentMigrator.Console/FluentMigrator.Console.csproj
@@ -6,10 +6,17 @@
     <PackageId>FluentMigrator.Console</PackageId>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\FluentMigrator.snk</AssemblyOriginatorKeyFile>
-    <Description>Console runner for FluentMigrator</Description>
+    <Description>Rev's fork for the FluentMigrator.Console found at https://github.com/revdotcom/fluentmigrator to handle our own flavor of default constraint naming.
+</Description>
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <RuntimeIdentifiers>win7-x86;win7-x64;any</RuntimeIdentifiers>
+    <Authors>Rev.com</Authors>
+    <Version>3.2.10.1</Version>
+    <Company>Rev</Company>
+    <PackageProjectUrl>https://github.com/revdotcom/fluentmigrator</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/revdotcom/fluentmigrator</RepositoryUrl>
+    <PackageReleaseNotes>Overide default constraint naming</PackageReleaseNotes>
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)../../PackageTool.props" />
   <ItemGroup>

--- a/src/FluentMigrator.Console/Rev.FluentMigrator.Console.nuspec
+++ b/src/FluentMigrator.Console/Rev.FluentMigrator.Console.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>Rev.FluentMigrator.Console</id>
     <version>3.2.10.1</version>

--- a/src/FluentMigrator.Console/Rev.FluentMigrator.Console.nuspec
+++ b/src/FluentMigrator.Console/Rev.FluentMigrator.Console.nuspec
@@ -2,18 +2,24 @@
 <package>
   <metadata>
     <id>Rev.FluentMigrator.Console</id>
-    <version>3.2.10.1</version>
+    <version>3.2.10</version>
     <authors>bryan</authors>
-    <description>Rev's fork for the FluentMigrator.Console found at https://github.com/revdotcom/fluentmigrator to handle our own flavor of default constraint naming.</description>
+    <description>Rev's fork for the FluentMigrator.Console found at https://github.com/revdotcom/fluentmigrator to handle our own flavor of default constraint naming.
+When installed it will add the FluentMigrator.Console's Migrate.exe and all needed libs in a folder called migrate in your build output folder</description>
     <copyright>Copyright 2020 Rev.com</copyright>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/revdotcom/fluentmigrator</projectUrl>
     <iconUrl>https://github.com/revdotcom/fluentmigrator/raw/develop/docs/logo.png</iconUrl>
     <repository type="git" url="https://github.com/revdotcom/fluentmigrator.git" />
-
+    <contentFiles> 
+      <!-- This is what tells nuget to copy the files in contentFiles to be copied to the output folder -->
+      <files include="**" buildAction="None" copyToOutput="true" flatten="false" /> 
+    </contentFiles> 
   </metadata>
+
   <files>
-    <!-- Include everything in \build -->
-    <file src="bin\Release\net461\**" target="build" />
+    <!-- This tells nuget to move the build files to the contentFiles folder in the nuget package -->
+    <!-- contentFiles is the modern way to do this, the content folder is legacy at this point -->
+    <file src="bin\Release\net461\**" target="contentFiles\any\any\migrate" />
   </files>
 </package>

--- a/src/FluentMigrator.Console/Rev.FluentMigrator.Console.nuspec
+++ b/src/FluentMigrator.Console/Rev.FluentMigrator.Console.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Rev.FluentMigrator.Console</id>
+    <version>3.2.10.1</version>
+    <authors>bryan</authors>
+    <description>Rev's fork for the FluentMigrator.Console found at https://github.com/revdotcom/fluentmigrator to handle our own flavor of default constraint naming.</description>
+    <copyright>Copyright 2020 Rev.com</copyright>
+    <license type="expression">Apache-2.0</license>
+    <projectUrl>https://github.com/revdotcom/fluentmigrator</projectUrl>
+    <iconUrl>https://github.com/revdotcom/fluentmigrator/raw/develop/docs/logo.png</iconUrl>
+    <repository type="git" url="https://github.com/revdotcom/fluentmigrator.git" />
+
+  </metadata>
+  <files>
+    <!-- Include everything in \build -->
+    <file src="bin\Release\net461\**" target="build" />
+  </files>
+</package>

--- a/src/FluentMigrator.Extensions.Oracle/FluentMigrator.Extensions.Oracle.csproj
+++ b/src/FluentMigrator.Extensions.Oracle/FluentMigrator.Extensions.Oracle.csproj
@@ -15,6 +15,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Abstractions\FluentMigrator.Abstractions.csproj" />
+    <PackageReference Include="FluentMigrator.Abstractions" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Extensions.Postgres/FluentMigrator.Extensions.Postgres.csproj
+++ b/src/FluentMigrator.Extensions.Postgres/FluentMigrator.Extensions.Postgres.csproj
@@ -12,6 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Abstractions\FluentMigrator.Abstractions.csproj" />
+    <PackageReference Include="FluentMigrator.Abstractions" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Extensions.SqlAnywhere/FluentMigrator.Extensions.SqlAnywhere.csproj
+++ b/src/FluentMigrator.Extensions.SqlAnywhere/FluentMigrator.Extensions.SqlAnywhere.csproj
@@ -15,6 +15,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Abstractions\FluentMigrator.Abstractions.csproj" />
+    <PackageReference Include="FluentMigrator.Abstractions" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Extensions.SqlServer/FluentMigrator.Extensions.SqlServer.csproj
+++ b/src/FluentMigrator.Extensions.SqlServer/FluentMigrator.Extensions.SqlServer.csproj
@@ -15,6 +15,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Abstractions\FluentMigrator.Abstractions.csproj" />
+    <PackageReference Include="FluentMigrator.Abstractions" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Core/FluentMigrator.Runner.Core.csproj
+++ b/src/FluentMigrator.Runner.Core/FluentMigrator.Runner.Core.csproj
@@ -8,15 +8,13 @@
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)../../PackageLibrary.props" />
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Abstractions\FluentMigrator.Abstractions.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="BatchParser" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FluentMigrator.Abstractions" Version="3.2.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.1" />

--- a/src/FluentMigrator.Runner.Db2/FluentMigrator.Runner.Db2.csproj
+++ b/src/FluentMigrator.Runner.Db2/FluentMigrator.Runner.Db2.csproj
@@ -12,6 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Firebird/FluentMigrator.Runner.Firebird.csproj
+++ b/src/FluentMigrator.Runner.Firebird/FluentMigrator.Runner.Firebird.csproj
@@ -12,9 +12,7 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
-  </ItemGroup>
-  <ItemGroup>
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Hana/FluentMigrator.Runner.Hana.csproj
+++ b/src/FluentMigrator.Runner.Hana/FluentMigrator.Runner.Hana.csproj
@@ -12,6 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Jet/FluentMigrator.Runner.Jet.csproj
+++ b/src/FluentMigrator.Runner.Jet/FluentMigrator.Runner.Jet.csproj
@@ -12,6 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.MySql/FluentMigrator.Runner.MySql.csproj
+++ b/src/FluentMigrator.Runner.MySql/FluentMigrator.Runner.MySql.csproj
@@ -12,6 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Oracle/FluentMigrator.Runner.Oracle.csproj
+++ b/src/FluentMigrator.Runner.Oracle/FluentMigrator.Runner.Oracle.csproj
@@ -12,7 +12,9 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Extensions.Oracle\FluentMigrator.Extensions.Oracle.csproj" />
-    <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Postgres/FluentMigrator.Runner.Postgres.csproj
+++ b/src/FluentMigrator.Runner.Postgres/FluentMigrator.Runner.Postgres.csproj
@@ -12,7 +12,9 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Extensions.Postgres\FluentMigrator.Extensions.Postgres.csproj" />
-    <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.Redshift/FluentMigrator.Runner.Redshift.csproj
+++ b/src/FluentMigrator.Runner.Redshift/FluentMigrator.Runner.Redshift.csproj
@@ -12,6 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.SQLite/FluentMigrator.Runner.SQLite.csproj
+++ b/src/FluentMigrator.Runner.SQLite/FluentMigrator.Runner.SQLite.csproj
@@ -12,6 +12,6 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.SqlAnywhere/FluentMigrator.Runner.SqlAnywhere.csproj
+++ b/src/FluentMigrator.Runner.SqlAnywhere/FluentMigrator.Runner.SqlAnywhere.csproj
@@ -13,10 +13,12 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Extensions.SqlAnywhere\FluentMigrator.Extensions.SqlAnywhere.csproj" />
-    <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Generators\" />
     <Folder Include="Processors\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.SqlServer/FluentMigrator.Runner.SqlServer.csproj
+++ b/src/FluentMigrator.Runner.SqlServer/FluentMigrator.Runner.SqlServer.csproj
@@ -13,7 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Extensions.SqlServer\FluentMigrator.Extensions.SqlServer.csproj" />
-    <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Data.SqlClient">
@@ -22,5 +21,8 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="BatchParser" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
   </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2000Column.cs
+++ b/src/FluentMigrator.Runner.SqlServer/Generators/SqlServer/SqlServer2000Column.cs
@@ -70,7 +70,7 @@ namespace FluentMigrator.Runner.Generators.SqlServer
 
         public static string GetDefaultConstraintName(string tableName, string columnName)
         {
-            return string.Format("DF_{0}_{1}", tableName, columnName);
+            return string.Format("{0}_{1}_Def", tableName, columnName);
         }
     }
 }

--- a/src/FluentMigrator.Runner.SqlServerCe/FluentMigrator.Runner.SqlServerCe.csproj
+++ b/src/FluentMigrator.Runner.SqlServerCe/FluentMigrator.Runner.SqlServerCe.csproj
@@ -48,4 +48,7 @@
       <HintPath>..\..\lib\SQLServerCE4\System.Data.SqlServerCe.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
+  </ItemGroup>
 </Project>

--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
-    <ProjectReference Include="..\FluentMigrator\FluentMigrator.csproj" />
     <ProjectReference Include="..\FluentMigrator.Runner.Db2\FluentMigrator.Runner.Db2.csproj" />
     <ProjectReference Include="..\FluentMigrator.Runner.Firebird\FluentMigrator.Runner.Firebird.csproj" />
     <ProjectReference Include="..\FluentMigrator.Runner.MySql\FluentMigrator.Runner.MySql.csproj" />
@@ -31,6 +30,7 @@
     <None Include="..\..\FluentMigrator.snk" Link="FluentMigrator.snk" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FluentMigrator" Version="3.2.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
   </ItemGroup>

--- a/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
+++ b/src/FluentMigrator.Runner/FluentMigrator.Runner.csproj
@@ -10,7 +10,6 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentMigrator.Runner.Core\FluentMigrator.Runner.Core.csproj" />
     <ProjectReference Include="..\FluentMigrator.Runner.Db2\FluentMigrator.Runner.Db2.csproj" />
     <ProjectReference Include="..\FluentMigrator.Runner.Firebird\FluentMigrator.Runner.Firebird.csproj" />
     <ProjectReference Include="..\FluentMigrator.Runner.MySql\FluentMigrator.Runner.MySql.csproj" />
@@ -31,6 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentMigrator" Version="3.2.10" />
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="3.2.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Uses signed versions of the core libraries and changes the sqlserver driver.

Not this is merging into a new branch that is a hard reset of the repo to the point of v3.2.10. This branch will need to become the new master as the old one is useless. However we can keep the old version around as a branch. Or we could keep the new version as a branch only. I don't care which.